### PR TITLE
TypeScript CommonJS test

### DIFF
--- a/test/es-module/test-typescript-commonjs.mjs
+++ b/test/es-module/test-typescript-commonjs.mjs
@@ -3,7 +3,7 @@ import * as fixtures from '../common/fixtures.mjs';
 import { match, strictEqual } from 'node:assert';
 import { test } from 'node:test';
 
-test('expect failure of a mts file with commonjs syntax', async () => {
+test('expect failure of an .mts file with CommonJS syntax', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     fixtures.path('typescript/cts/test-cts-but-module-syntax.cts'),
@@ -14,7 +14,7 @@ test('expect failure of a mts file with commonjs syntax', async () => {
   strictEqual(result.code, 1);
 });
 
-test('execute of a cts file import cts module', async () => {
+test('execute a .cts file importing a .cts file', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     fixtures.path('typescript/cts/test-require-commonjs.cts'),
@@ -25,7 +25,7 @@ test('execute of a cts file import cts module', async () => {
   strictEqual(result.code, 0);
 });
 
-test('execute a cts file importing ts export', async () => {
+test('execute a .cts file importing a .ts file export', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     fixtures.path('typescript/cts/test-require-ts-file.cts'),
@@ -36,7 +36,7 @@ test('execute a cts file importing ts export', async () => {
   strictEqual(result.code, 0);
 });
 
-test('execute a cts file importing mts export', async () => {
+test('execute a .cts file importing a .mts file export', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     fixtures.path('typescript/cts/test-require-mts-module.cts'),
@@ -47,7 +47,7 @@ test('execute a cts file importing mts export', async () => {
   strictEqual(result.code, 1);
 });
 
-test('execute a cts file importing mts export', async () => {
+test('execute a .cts file importing a .mts file export', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     '--experimental-require-module',
@@ -59,7 +59,7 @@ test('execute a cts file importing mts export', async () => {
   strictEqual(result.code, 0);
 });
 
-test('expect failure of a cts with default type module', async () => {
+test('expect failure of a .cts file with default type module', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     '--experimental-default-type=module', // Keeps working with commonjs
@@ -71,7 +71,7 @@ test('expect failure of a cts with default type module', async () => {
   strictEqual(result.code, 0);
 });
 
-test('expect failure of a cts with default type module', async () => {
+test('expect failure of a .cts file with default type module', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     fixtures.path('typescript/cts/test-cts-node_modules.cts'),
@@ -82,7 +82,7 @@ test('expect failure of a cts with default type module', async () => {
   strictEqual(result.code, 0);
 });
 
-test('expect failure of a cts with default type module', async () => {
+test('expect failure of a .cts file with default type module', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     fixtures.path('typescript/cts/test-ts-node_modules.cts'),
@@ -93,7 +93,7 @@ test('expect failure of a cts with default type module', async () => {
   strictEqual(result.code, 0);
 });
 
-test('expect failure of a cts with default type module', async () => {
+test('expect failure of a .cts file with default type module', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     fixtures.path('typescript/cts/test-mts-node_modules.cts'),
@@ -104,7 +104,7 @@ test('expect failure of a cts with default type module', async () => {
   strictEqual(result.code, 1);
 });
 
-test('expect failure of a cts with default type module', async () => {
+test('expect failure of a .cts file with default type module', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     '--experimental-require-module',

--- a/test/es-module/test-typescript-commonjs.mjs
+++ b/test/es-module/test-typescript-commonjs.mjs
@@ -3,6 +3,34 @@ import * as fixtures from '../common/fixtures.mjs';
 import { match, strictEqual } from 'node:assert';
 import { test } from 'node:test';
 
+test('require a .ts file with explicit extension succeeds', async () => {
+  const result = await spawnPromisified(process.execPath, [
+    '--experimental-strip-types',
+    '--eval',
+    'require("./test-typescript.ts")',
+  ], {
+    cwd: fixtures.path('typescript/ts'),
+  });
+
+  strictEqual(result.stderr, '');
+  strictEqual(result.stdout, 'Hello, TypeScript!\n');
+  strictEqual(result.code, 0);
+});
+
+test('require a .ts file with implicit extension fails', async () => {
+  const result = await spawnPromisified(process.execPath, [
+    '--experimental-strip-types',
+    '--eval',
+    'require("./test-typescript")',
+  ], {
+    cwd: fixtures.path('typescript/ts'),
+  });
+
+  match(result.stderr, /ENOENT.*Did you mean to import .*test-typescript\.ts"\?/s);
+  strictEqual(result.stdout, '');
+  strictEqual(result.code, 1);
+});
+
 test('expect failure of an .mts file with CommonJS syntax', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',

--- a/test/es-module/test-typescript-eval.mjs
+++ b/test/es-module/test-typescript-eval.mjs
@@ -2,7 +2,7 @@ import { spawnPromisified } from '../common/index.mjs';
 import { match, strictEqual } from 'node:assert';
 import { test } from 'node:test';
 
-test('eval typescript esm syntax', async () => {
+test('eval TypeScript ESM syntax', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--input-type=module',
     '--experimental-strip-types',
@@ -16,7 +16,7 @@ test('eval typescript esm syntax', async () => {
   strictEqual(result.code, 0);
 });
 
-test('eval typescript cjs syntax', async () => {
+test('eval TypeScript CommonJS syntax', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--input-type=commonjs',
     '--experimental-strip-types',
@@ -29,7 +29,7 @@ test('eval typescript cjs syntax', async () => {
   strictEqual(result.code, 0);
 });
 
-test('eval typescript cjs syntax by default', async () => {
+test('eval TypeScript CommonJS syntax by default', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     '--eval',
@@ -42,7 +42,7 @@ test('eval typescript cjs syntax by default', async () => {
   strictEqual(result.code, 0);
 });
 
-test('fail typescript esm syntax if not specified', async () => {
+test('fail TypeScript ESM syntax if not specified', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     '--eval',
@@ -54,7 +54,7 @@ test('fail typescript esm syntax if not specified', async () => {
   strictEqual(result.code, 1);
 });
 
-test('expect fail eval typescript cjs syntax with input-type module', async () => {
+test('expect fail eval TypeScript CommonJS syntax with input-type module', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     '--input-type=module',
@@ -68,7 +68,7 @@ test('expect fail eval typescript cjs syntax with input-type module', async () =
   strictEqual(result.code, 1);
 });
 
-test('expect fail eval typescript cjs syntax with input-type module', async () => {
+test('expect fail eval TypeScript CommonJS syntax with input-type module', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     '--input-type=commonjs',

--- a/test/es-module/test-typescript-module.mjs
+++ b/test/es-module/test-typescript-module.mjs
@@ -3,7 +3,7 @@ import * as fixtures from '../common/fixtures.mjs';
 import { match, strictEqual } from 'node:assert';
 import { test } from 'node:test';
 
-test('expect failure of a mts file with commonjs syntax', async () => {
+test('expect failure of a .mts file with CommonJS syntax', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     fixtures.path('typescript/mts/test-mts-but-commonjs-syntax.mts'),
@@ -14,7 +14,7 @@ test('expect failure of a mts file with commonjs syntax', async () => {
   strictEqual(result.code, 1);
 });
 
-test('execute of a mts file import mts module', async () => {
+test('execute an .mts file importing an .mts file', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     fixtures.path('typescript/mts/test-import-module.mts'),
@@ -25,7 +25,7 @@ test('execute of a mts file import mts module', async () => {
   strictEqual(result.code, 0);
 });
 
-test('execute a mts file importing ts module', async () => {
+test('execute an .mts file importing a .ts file', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     '--experimental-default-type=module', // this should fail
@@ -37,7 +37,7 @@ test('execute a mts file importing ts module', async () => {
   strictEqual(result.code, 0);
 });
 
-test('execute a mts file importing cts module', async () => {
+test('execute an .mts file importing a .cts file', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     fixtures.path('typescript/mts/test-import-commonjs.mts'),
@@ -48,7 +48,7 @@ test('execute a mts file importing cts module', async () => {
   strictEqual(result.code, 0);
 });
 
-test('execute of a mts file with wrong default module', async () => {
+test('execute an .mts file with wrong default module', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     '--experimental-default-type=commonjs',
@@ -60,7 +60,7 @@ test('execute of a mts file with wrong default module', async () => {
   strictEqual(result.code, 1);
 });
 
-test('execute of a mts file from node_modules', async () => {
+test('execute an .mts file from node_modules', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     fixtures.path('typescript/mts/test-mts-node_modules.mts'),
@@ -71,7 +71,7 @@ test('execute of a mts file from node_modules', async () => {
   strictEqual(result.code, 0);
 });
 
-test('execute of a cts file from node_modules', async () => {
+test('execute a .cts file from node_modules', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     fixtures.path('typescript/mts/test-cts-node_modules.mts'),
@@ -82,7 +82,7 @@ test('execute of a cts file from node_modules', async () => {
   strictEqual(result.code, 0);
 });
 
-test('execute of a ts file from node_modules', async () => {
+test('execute a .ts file from node_modules', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     fixtures.path('typescript/mts/test-ts-node_modules.mts'),

--- a/test/es-module/test-typescript.mjs
+++ b/test/es-module/test-typescript.mjs
@@ -3,7 +3,7 @@ import * as fixtures from '../common/fixtures.mjs';
 import { match, strictEqual } from 'node:assert';
 import { test } from 'node:test';
 
-test('execute a typescript file', async () => {
+test('execute a TypeScript file', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     fixtures.path('typescript/ts/test-typescript.ts'),
@@ -14,7 +14,7 @@ test('execute a typescript file', async () => {
   strictEqual(result.code, 0);
 });
 
-test('execute a typescript file with imports', async () => {
+test('execute a TypeScript file with imports', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     '--experimental-default-type=module',
@@ -26,7 +26,7 @@ test('execute a typescript file with imports', async () => {
   strictEqual(result.code, 0);
 });
 
-test('execute a typescript with node_modules', async () => {
+test('execute a TypeScript file with node_modules', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     '--experimental-default-type=module',
@@ -38,7 +38,7 @@ test('execute a typescript with node_modules', async () => {
   strictEqual(result.code, 0);
 });
 
-test('expect error when executing a typescript file with imports with no extensions', async () => {
+test('expect error when executing a TypeScript file with imports with no extensions', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     '--experimental-default-type=module',
@@ -50,7 +50,7 @@ test('expect error when executing a typescript file with imports with no extensi
   strictEqual(result.code, 1);
 });
 
-test('expect error when executing a typescript file with enum', async () => {
+test('expect error when executing a TypeScript file with enum', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     fixtures.path('typescript/ts/test-enums.ts'),
@@ -62,7 +62,7 @@ test('expect error when executing a typescript file with enum', async () => {
   strictEqual(result.code, 1);
 });
 
-test('expect error when executing a typescript file with experimental decorators', async () => {
+test('expect error when executing a TypeScript file with experimental decorators', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     fixtures.path('typescript/ts/test-experimental-decorators.ts'),
@@ -73,7 +73,7 @@ test('expect error when executing a typescript file with experimental decorators
   strictEqual(result.code, 1);
 });
 
-test('expect error when executing a typescript file with namespaces', async () => {
+test('expect error when executing a TypeScript file with namespaces', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     fixtures.path('typescript/ts/test-namespaces.ts'),
@@ -84,7 +84,7 @@ test('expect error when executing a typescript file with namespaces', async () =
   strictEqual(result.code, 1);
 });
 
-test('execute a typescript file with type definition', async () => {
+test('execute a TypeScript file with type definition', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     fixtures.path('typescript/ts/test-import-types.ts'),
@@ -95,7 +95,7 @@ test('execute a typescript file with type definition', async () => {
   strictEqual(result.code, 0);
 });
 
-test('execute a typescript file with commonjs syntax', async () => {
+test('execute a TypeScript file with CommonJS syntax', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     fixtures.path('typescript/ts/test-commonjs-parsing.ts'),
@@ -105,7 +105,7 @@ test('execute a typescript file with commonjs syntax', async () => {
   strictEqual(result.code, 0);
 });
 
-test('execute a ts file with module syntax', async () => {
+test('execute a TypeScript file with ES module syntax', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     '--experimental-default-type=module',
@@ -117,7 +117,7 @@ test('execute a ts file with module syntax', async () => {
   strictEqual(result.code, 0);
 });
 
-test('expect failure of a ts file requiring esm syntax', async () => {
+test('expect failure of a TypeScript file requiring ES module syntax', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     '--experimental-require-module',
@@ -129,7 +129,7 @@ test('expect failure of a ts file requiring esm syntax', async () => {
   strictEqual(result.code, 0);
 });
 
-test('expect stacktrace of a ts file to be corrct', async () => {
+test('expect stack trace of a TypeScript file to be correct', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     fixtures.path('typescript/ts/test-whitespacing.ts'),
@@ -140,7 +140,7 @@ test('expect stacktrace of a ts file to be corrct', async () => {
   strictEqual(result.code, 1);
 });
 
-test('execute commonjs ts file from node_modules with require module', async () => {
+test('execute CommonJS TypeScript file from node_modules with require-module', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-default-type=module',
     '--experimental-strip-types',
@@ -152,7 +152,7 @@ test('execute commonjs ts file from node_modules with require module', async () 
   strictEqual(result.code, 0);
 });
 
-test('execute a typescript file with commonjs syntax but default type module', async () => {
+test('execute a TypeScript file with CommonJS syntax but default type module', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     '--experimental-default-type=module',
@@ -163,7 +163,7 @@ test('execute a typescript file with commonjs syntax but default type module', a
   strictEqual(result.code, 1);
 });
 
-test('execute a typescript file with commonjs syntax requiring cts', async () => {
+test('execute a TypeScript file with CommonJS syntax requiring .cts', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     fixtures.path('typescript/ts/test-require-cts.ts'),
@@ -174,7 +174,7 @@ test('execute a typescript file with commonjs syntax requiring cts', async () =>
   strictEqual(result.code, 0);
 });
 
-test('execute a typescript file with commonjs syntax requiring mts', async () => {
+test('execute a TypeScript file with CommonJS syntax requiring .mts', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     fixtures.path('typescript/ts/test-require-mts.ts'),
@@ -185,7 +185,7 @@ test('execute a typescript file with commonjs syntax requiring mts', async () =>
   strictEqual(result.code, 1);
 });
 
-test('execute a typescript file with commonjs syntax requiring mts with require module', async () => {
+test('execute a TypeScript file with CommonJS syntax requiring .mts with require-module', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     '--experimental-require-module',
@@ -197,7 +197,7 @@ test('execute a typescript file with commonjs syntax requiring mts with require 
   strictEqual(result.code, 0);
 });
 
-test('execute a typescript file with commonjs syntax requiring mts with require module', async () => {
+test('execute a TypeScript file with CommonJS syntax requiring .mts with require-module', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--experimental-strip-types',
     '--experimental-default-type=commonjs',


### PR DESCRIPTION
Builds on #5 

The second test here, that `require('./test-typescript')` should error, currently fails. It should pass.

I suspect that removing the `Module._extensions` stuff should fix that, and we need to remove those entries in order for type stripping to not be a semver-major change when it’s unflagged. Making such a change will mean that the CommonJS loader would never process TypeScript files, which is fine; they would become like `.mjs` files, always handled by the ESM loader, whether or not they’re evaluated as ESM or as CommonJS. (There are references in the codebase of the ESM loader being renamed to things like Cascaded Loader, to emphasize that it’s more the “new” loader and the CommonJS loader is the legacy one; the new loader can handle all file types.)